### PR TITLE
Update documentation to match functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ convert(..., fits_extension=[0, 1, "ERR"])
 | Parameter              | Description                                     | Default       |
 | ---------------------- | ----------------------------------------------- | ------------- |
 | `chunk_shape`          | Zarr chunk dimensions (n_images, height, width) | (1, 256, 256) |
-| `shard_bytes`          | Target shard size in bytes                      | 16 MB         |
-| `compressor`           | Compression codec (zstd, lz4, gzip, etc.)       | "zstd"        |
-| `clevel`               | Compression level (1-9)                         | 4             |
+| `compressor`           | Compression codec (zstd, lz4, gzip, etc.)       | "lz4"         |
+| `clevel`               | Compression level (1-9)                         | 1             |
 | `num_parallel_workers` | Number of processing threads                    | 8             |
+| `recursive`            | Scan subdirectories recursively                 | False         |
+| `fits_extension`       | FITS HDU(s) to read (int, str, or sequence)     | None (uses 0) |
+| `overwrite`            | Overwrite existing store if present             | False         |
 
 ## Output Structure
 
@@ -209,7 +211,7 @@ Total images across all files: 104,857,600
 Total storage size: 126,743.31 MB
 Image dimensions: (3, 256, 256)
 Data type: uint8
-Compression: zstd (level 4)
+Compression: lz4 (level 1)
 
 Format distribution:
   FITS: 60,000,000 (57.2%)

--- a/images_to_zarr/convert.py
+++ b/images_to_zarr/convert.py
@@ -241,8 +241,6 @@ def convert(
     chunk_shape
         Chunk layout **(n_images, height, width)** ; the first dimension
         **must be 1** so each image maps to exactly one chunk.
-    shard_bytes
-        Target size (bytes) of each shard container file.
     compressor
         Any *numcodecs* codec name (``"zstd"``, ``"lz4"``, …).
     clevel


### PR DESCRIPTION
as title

## AI Summary
This pull request updates the `README.md` and `images_to_zarr/convert.py` files to reflect changes in default compression settings and introduces new parameters for improved functionality. The most important changes include switching the default compression codec from `zstd` to `lz4`, adjusting the default compression level, and adding new options for recursive directory scanning, FITS extensions, and overwriting behavior.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R160): Updated the default compression codec from `"zstd"` to `"lz4"` and the compression level from `4` to `1`. Added new parameters: `recursive`, `fits_extension`, and `overwrite`, with descriptions and default values. Removed the `shard_bytes` parameter from the table.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L212-R214): Updated the example output to reflect the new default compression settings (`lz4` at level `1`).

### Code updates:
* [`images_to_zarr/convert.py`](diffhunk://#diff-1ff0e928a3445208c7fc79cb6f75d7c2b545c4f6189bb3597427f8b98b99f2cbL244-L245): Removed the `shard_bytes` parameter from the function documentation to align with the updated parameter set.